### PR TITLE
Fix "int expected" error on ListAddressTransactions

### DIFF
--- a/api_listaddresstransactions.go
+++ b/api_listaddresstransactions.go
@@ -1,16 +1,14 @@
 package multichain
 
-import "fmt"
-
-func (client *Client) ListAddressTransactions(address string, count, skip int, verbose bool) (Response, error) {
+func (client *Client) ListAddressTransactions(address string, count int, skip int, verbose bool) (Response, error) {
 
 	msg := client.Command(
 		"listaddresstransactions",
 		[]interface{}{
 			address,
-			fmt.Sprintf("count=%v", count),
-			fmt.Sprintf("skip=%v", skip),
-			fmt.Sprintf("verbose=%v", verbose),
+			count,
+			skip,
+			verbose,
 		},
 	)
 


### PR DESCRIPTION
The function didn't work because of int to string conversion, creating multichaind error « value is type string, int expected »