### PR TITLE
:bug: Recognize failed Resty requests

### DIFF
--- a/multichain.go
+++ b/multichain.go
@@ -49,7 +49,7 @@ func (client *Client) Post(msg interface{}) (Response, error) {
 		return nil, err
 	}
 
-	if obj["error"] != nil {
+	if obj == nil || obj["error"] != nil {
 		e := obj["error"].(map[string]interface{})
 		var s string
 		m, ok := msg.(map[string]interface{})


### PR DESCRIPTION
There are cases where marshalled `obj` is nil, but Resty doesn't provide a non-nil err.
For example if one sends non-hexadecimal encoded data with whitespaces/lf characters.